### PR TITLE
Initial version. TrakStart & TrakStop implemented.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{c,h,in,lua}]
+max_line_length = 150
+
+[*.py]
+indent_size = 4
+
+[{Makefile,**/Makefile,runtime/doc/*.txt}]
+indent_style = tab
+indent_size = 8

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# trak.nvim
+
+The Neovim plugin for [Trak](https://usetrak.com) CLI.

--- a/lua/trak/+
+++ b/lua/trak/+
@@ -1,0 +1,40 @@
+local D = require("trak.dbfunc")
+local U = require("trak.utils")
+local T = {}
+
+local usr_input_list = {
+  'project',
+  'tag',
+  'category',
+  'billable'
+}
+
+function T.create_session(t)
+  local r = {}
+  for _, k in pairs(t) do
+    local v = vim.fn.input(string.format("%s: ", k))
+    r[k] = v
+    xpcall(function assert(r['project'] ~= ''end),
+      function() vim.notify("You should provide a name for the session", vim.log.levels.ERROR) end)
+  end
+  r = vim.tbl_deep_extend('keep', r, U.record)
+  return r
+end
+
+function T.start()
+  D.init_db()
+
+  local r = T.create_session(usr_input_list)
+
+  local db = U.json_decode()
+  local t = vim.tbl_deep_extend('keep', r, U.record)
+
+  table.insert(db, t)
+  D.dinsert(db)
+end
+
+function T.stop()
+  D.dupdate()
+end
+
+return T

--- a/lua/trak/config.lua
+++ b/lua/trak/config.lua
@@ -1,0 +1,33 @@
+---@mod trak.config Config
+local Config = {
+  _ = {},
+  config = {
+    trak_folder = os.getenv('HOME') .. '/.trak',
+    db_filepath = os.getenv('HOME') .. '/.trak/db.json',
+    dev = { -- see: github.com/folke/lazy.nvim
+      enabled = false,
+      dev_trak_folder = "",
+      dev_db_filepath = ""
+    }
+    -- config_file_path = '' -- TODO: FEATURE
+  }
+}
+
+function Config:set(cfg)
+  if cfg then
+    self.config = vim.tbl_deep_extend('force', self.config, cfg)
+  end
+  return self
+end
+
+function Config:get() return self.config end
+
+return setmetatable(Config, {
+  __index = function(t, k)
+    return t._[k]
+  end,
+
+  __newindex = function(t, k, v)
+    t._[k] = v
+  end
+})

--- a/lua/trak/dbfunc.lua
+++ b/lua/trak/dbfunc.lua
@@ -1,0 +1,49 @@
+local cfg = require("trak.config").config
+local U = require("trak.utils")
+
+local D = {}
+
+function D.db_exists()
+  return vim.fn.findfile(cfg.db_filepath)
+end
+
+---Initialize the db file using the filepath from config
+---@return boolean
+function D.init_db()
+  if D.db_exists() == cfg.db_filepath then
+    return true
+  else
+    io.open(cfg.db_filepath, 'w'):close()
+    vim.notify(string.format("%s succesfully init!", cfg.db_filepath), vim.log.levels.INFO)
+    return true
+  end
+end
+
+---@param r Record[]
+---@return boolean
+function D.dinsert(r)
+  local db = io.open(cfg.db_filepath, 'w')
+
+  assert(db ~= nil, { msg = string.format('Failing insert new session in db, %s not found', cfg.db_filepath) })
+
+  db:write(U.json_encode(r))
+  db:close()
+  return true
+end
+
+function D.dupdate()
+  local db = U.json_decode(cfg.db_filepath)
+
+  assert(db ~= nil, { msg = string.format('Failing update db, %s not found', cfg.db_filepath) })
+
+  if db[#db]['end'] == '' then
+    db[#db]['end'] = os.date("%Y-%m-%dT%H:%M:%s")
+
+    if D.dinsert(db) then
+      return true
+    end
+  end
+  error('You don\'t have any active project!')
+end
+
+return D

--- a/lua/trak/init.lua
+++ b/lua/trak/init.lua
@@ -1,0 +1,49 @@
+local D = require("trak.dbfunc")
+local U = require("trak.utils")
+local T = {}
+
+local usr_input_list = {
+  'project',
+  'tag',
+  'category',
+  'billable'
+}
+
+function T.create_session(t)
+  local r = {}
+  for _, k in pairs(t) do
+    local v = vim.fn.input(string.format("%s: ", k))
+    r[k] = v
+    assert(r.project ~= '', "You should provide a name for the session")
+  end
+  r = vim.tbl_deep_extend('keep', r, U.record)
+  return r
+end
+
+function T.start()
+  D.init_db()
+
+
+  local db = U.json_decode()
+
+  -- This should be investigated.
+  -- It works as intented:
+  --  if project.end is empty should raise an error.
+  -- I don't understand how assert read this...
+  --  assert raise an error if expression is false...
+  -- why raise an error now?
+  assert(db[#db]['end'] ~= '',
+    string.format("You have the %s session in progress. Please stop that before start a new one!", db[#db]['project']))
+
+  local r = T.create_session(usr_input_list)
+  local t = vim.tbl_deep_extend('keep', r, U.record)
+
+  table.insert(db, t)
+  D.dinsert(db)
+end
+
+function T.stop()
+  D.dupdate()
+end
+
+return T

--- a/lua/trak/utils.lua
+++ b/lua/trak/utils.lua
@@ -1,0 +1,46 @@
+local cfg = require("trak.config").config
+
+local U = {}
+-- os.date("%Y-%m-%dT%H:%M:%s")
+---@class Record
+---@field project string
+---@field start osdate|string
+---@field end osdate|string
+---@field billable boolean
+---@field category string|string[]
+---@field tag string|string[]
+---@type Record
+U.record = {
+  project = '',
+  start = os.date("%Y-%m-%dT%H:%M:%s"),
+  ['end'] = '',
+  billable = false,
+  tag = '',
+  category = ''
+}
+
+
+--- Return a JSON formatted string from table
+---@param t table
+---@return string|nil
+function U.json_encode(t)
+  if not vim.tbl_isempty(t) then
+    return vim.json.encode(t)
+  end
+end
+
+--- Returns an array of tbl representing JSON object
+---@param f string|nil
+---@return table
+function U.json_decode(f)
+  f = f or cfg.db_filepath
+  local rf = io.open(f, 'r'):read('*a')
+
+  if rf ~= nil and rf ~= '' then
+    return vim.json.decode(rf)
+  else
+    return {}
+  end
+end
+
+return U

--- a/plugin/trak.lua
+++ b/plugin/trak.lua
@@ -1,0 +1,6 @@
+local T = require("trak.init")
+local A = vim.api
+
+
+A.nvim_create_user_command('TrakStart', function() T.start() end, { desc = "Start a Trak session" })
+A.nvim_create_user_command('TrakStop', function() T.stop() end, { desc = "Stop a Trak session" })


### PR DESCRIPTION
**Trak start and stop method implemented.**

I'm starting to think about binding the Trak CLI execution in nvim. This could make the development of the plugin extremely fast and if something changes on the official tools we should not re-implement all or part of the logic.

Once installed, just run ``:TrakStart`` this will prompt you for the necessary information and create the new entry in ``db.json`` if you don't have another open session.
run ``:TrakStop``to stop it
